### PR TITLE
Update aam-media-exploit.py to python3 as python2 is outdated

### DIFF
--- a/aam-media-exploit.py
+++ b/aam-media-exploit.py
@@ -1,19 +1,20 @@
+#! /usr/bin/env python3
 import wget
 import os
 from art import *
  
  
 Art =text2art("TuZ",font='block',chr_ignore=True)
-print Art
-print "*************************************************"
+print (Art)
+print ("*************************************************")
 print ("Advanced Access Manager 5.9.9 Exploit File Download by TuZ\n")
 print ("For info : https://github.com/Tuz-Wwsd/Advanced-Access-Manager-5.9.9-Exploit-file-download \n")
-print "*************************************************"
+print ("*************************************************")
  
  
 # Read input
-url = raw_input("Inser url ( http://site.com):\n")
-file = raw_input("Inser file list:\n")
+url = input("Insert url ( http://site.com):\n")
+file = input("Insert file list:\n")
  
  
 f = open(file)


### PR DESCRIPTION
Python2 is outdated and most users find hard time to use pip to install wget and art module.  pip2 is not installed in kali and other modern repos.
Python3 is easy to use, so updated it to python3.